### PR TITLE
feat: add include-changelog functionality

### DIFF
--- a/.changeset/cuddly-pears-speak.md
+++ b/.changeset/cuddly-pears-speak.md
@@ -1,0 +1,5 @@
+---
+'dependabot-changesets': minor
+---
+
+Add `include-changelog` option to add more context for updates in a collapsed block.

--- a/README.md
+++ b/README.md
@@ -38,3 +38,17 @@ jobs:
           pr-number: ${{ github.event.pull_request.number }}
           token: ${{ secrets.CHANGESET_GITHUB_TOKEN }}
 ```
+
+## Configuration
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `owner` | The owner of the repository | Yes | N/A |
+| `repo` | The name of the repository | Yes | N/A |
+| `pr-number` | The number of the PR to process | Yes | N/A |
+| `token` | The GitHub token to use for API requests | Yes | N/A |
+| `package-name` | The name of the package to use in the changeset | No | Same as `repo` |
+| `update-type` | The type of update to use in the changeset | No | `patch` |
+| `git-user` | The user to use for git commits | No | `dependabot[bot]` |
+| `git-email` | The email to use for git commits | No | `49699333+dependabot[bot]@users.noreply.github.com` |
+| `include-changelog` | Whether to include the changelog from Dependabot PRs in the generated changeset | No | `false` |

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,0 +1,119 @@
+import * as core from '@actions/core';
+import * as github from '@actions/github';
+import { readFile, writeFile } from 'fs/promises';
+import { run } from '../src/main';
+import { jest } from '@jest/globals';
+
+// Mock the GitHub API and core module
+jest.mock('@actions/github');
+jest.mock('@actions/core');
+jest.mock('@actions/exec');
+jest.mock('fs/promises');
+
+describe('run', () => {
+	const mockOctokit = {
+		rest: {
+			pulls: {
+				get: jest.fn(),
+				listCommits: jest.fn(),
+			},
+		},
+	};
+
+	beforeEach(() => {
+		// Reset all mocks
+		jest.resetAllMocks();
+		(github.getOctokit as jest.Mock).mockReturnValue(mockOctokit);
+		(readFile as jest.Mock).mockImplementation(() => Promise.resolve('mock file content'));
+		(writeFile as jest.Mock).mockImplementation(() => Promise.resolve());
+
+		// Mock core.getInput for required inputs
+		(core.getInput as jest.Mock).mockImplementation((name) => {
+			switch (name) {
+				case 'owner':
+					return 'test-owner';
+				case 'repo':
+					return 'test-repo';
+				case 'pr-number':
+					return '123';
+				case 'token':
+					return 'test-token';
+				default:
+					return '';
+			}
+		});
+	});
+
+	it('extracts changelog when include-changelog is true', async () => {
+		// Mock PR response with changelog
+		const mockPRBody = `
+<details>
+<summary>Release notes</summary>
+<p><em>Sourced from <a href="https://github.com/nextauthjs/next-auth/releases"><code>@auth/sveltekit</code>'s releases</a>.</em></p>
+<blockquote>
+<h2><code>@auth/sveltekit</code> 0.3.12</h2>
+<h2>Other</h2>
+<ul>
+<li><strong><code>@auth/core</code></strong>: cookies cleanup (#9111) (ee88375f)</li>
+<li><strong><code>@auth/core</code></strong>: typo in apple.ts (#9093) (419b66d0)</li>
+</ul>
+</blockquote>
+</details>`;
+
+		mockOctokit.rest.pulls.get.mockImplementation(() => Promise.resolve({
+			data: {
+				title: 'Bump @auth/sveltekit from 0.3.11 to 0.3.12',
+				body: mockPRBody,
+			},
+			status: 200
+		}));
+
+		// Mock include-changelog input as true
+		(core.getInput as jest.Mock).mockImplementation((name) => {
+			switch (name) {
+				case 'include-changelog':
+					return 'true';
+				default:
+					return '';
+			}
+		});
+
+		await run();
+
+		// Verify that writeFile was called with content containing changelog
+		const writeFileCalls = (writeFile as jest.Mock).mock.calls;
+		const hasChangelog = writeFileCalls.some((call) => {
+			const content = call[1] as string;
+			return content.includes('<details>') &&
+				content.includes('Release notes');
+		});
+		expect(hasChangelog).toBe(true);
+	});
+
+	it('does not extract changelog when include-changelog is false', async () => {
+		// Mock PR response with changelog
+		mockOctokit.rest.pulls.get.mockImplementation(() => Promise.resolve({
+			data: {
+				title: 'Bump @auth/sveltekit from 0.3.11 to 0.3.12',
+				body: 'mock PR body with changelog',
+			},
+		}));
+
+		// Mock include-changelog input as false (default)
+		(core.getInput as jest.Mock).mockImplementation((name) => {
+			if (name === 'include-changelog') return 'false';
+			return '';
+		});
+
+		await run();
+
+		// Verify that writeFile was called with content not containing changelog
+		const writeFileCalls = (writeFile as jest.Mock).mock.calls;
+		const hasChangelog = writeFileCalls.some((call) => {
+			const content = call[1] as string;
+			return content.includes('<details>') ||
+				content.includes('Release notes');
+		});
+		expect(hasChangelog).toBe(false);
+	});
+});

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -44,25 +44,73 @@ describe('run', () => {
 		});
 	});
 
-	it('extracts changelog when include-changelog is true', async () => {
+	it('extracts changelog for single package PR when include-changelog is true', async () => {
 		// Mock PR response with changelog
 		const mockPRBody = `
+Bumps [nanoid](https://github.com/ai/nanoid) from 3.3.6 to 3.3.8.
 <details>
-<summary>Release notes</summary>
-<p><em>Sourced from <a href="https://github.com/nextauthjs/next-auth/releases"><code>@auth/sveltekit</code>'s releases</a>.</em></p>
+<summary>Changelog</summary>
+<p><em>Sourced from <a href="https://github.com/ai/nanoid/blob/main/CHANGELOG.md">nanoid's changelog</a>.</em></p>
 <blockquote>
-<h2><code>@auth/sveltekit</code> 0.3.12</h2>
-<h2>Other</h2>
+<h2>3.3.8</h2>
 <ul>
-<li><strong><code>@auth/core</code></strong>: cookies cleanup (#9111) (ee88375f)</li>
-<li><strong><code>@auth/core</code></strong>: typo in apple.ts (#9093) (419b66d0)</li>
+<li>Fixed a way to break Nano ID by passing non-integer size (by <a href="https://github.com/myndzi"><code>@​myndzi</code></a>).</li>
+</ul>
+<h2>3.3.7</h2>
+<ul>
+<li>Fixed <code>node16</code> TypeScript support (by Saadi Myftija).</li>
 </ul>
 </blockquote>
+</details>
+<details>
+<summary>Commits</summary>
+<ul>
+<li><a href="https://github.com/ai/nanoid/commit/3044cd5e73f4cf31795f61f6e6b961c8c0a5c744"><code>3044cd5</code></a> Release 3.3.8 version</li>
+<li><a href="https://github.com/ai/nanoid/commit/4fe34959c34e5b3573889ed4f24fe91d1d3e7231"><code>4fe3495</code></a> Update size limit</li>
+<li><a href="https://github.com/ai/nanoid/commit/d643045f40d6dc8afa000a644d857da1436ed08c"><code>d643045</code></a> Fix pool pollution, infinite loop (<a href="https://redirect.github.com/ai/nanoid/issues/510">#510</a>)</li>
+<li><a href="https://github.com/ai/nanoid/commit/89d82d2ce4b0411e73ac7ccfe57bc03e932416e2"><code>89d82d2</code></a> Release 3.3.7 version</li>
+<li><a href="https://github.com/ai/nanoid/commit/5022c35acaaedd9da4b56cad37b02bbcb87635e1"><code>5022c35</code></a> Update dual-publish</li>
+<li><a href="https://github.com/ai/nanoid/commit/3e7a8e557b9d93a582ef2c3bb9f7306fc339ef35"><code>3e7a8e5</code></a> Remove benchmark from CI for v3</li>
+<li><a href="https://github.com/ai/nanoid/commit/d3561446aee52fdf38325e1d30c905d989a8ccd2"><code>d356144</code></a> Fix CI for v3</li>
+<li><a href="https://github.com/ai/nanoid/commit/37b25dfac2edfd73d7bbc88886e4c6067fac8619"><code>37b25df</code></a> Move to pnpm 8</li>
+<li>See full diff in <a href="https://github.com/ai/nanoid/compare/3.3.6...3.3.8">compare view</a></li>
+</ul>
+</details>
+<br />
+
+
+[![Dependabot compatibility score](https://dependabot-badges.githubapp.com/badges/compatibility_score?dependency-name=nanoid&package-manager=npm_and_yarn&previous-version=3.3.6&new-version=3.3.8)](https://docs.github.com/en/github/managing-security-vulnerabilities/about-dependabot-security-updates#about-compatibility-scores)
+
+Dependabot will resolve any conflicts with this PR as long as you don't alter it yourself. You can also trigger a rebase manually by commenting \`@dependabot rebase\`.
+
+[//]: # (dependabot-automerge-start)
+[//]: # (dependabot-automerge-end)
+
+---
+
+<details>
+<summary>Dependabot commands and options</summary>
+<br />
+
+You can trigger Dependabot actions by commenting on this PR:
+- \`@dependabot rebase\` will rebase this PR
+- \`@dependabot recreate\` will recreate this PR, overwriting any edits that have been made to it
+- \`@dependabot merge\` will merge this PR after your CI passes on it
+- \`@dependabot squash and merge\` will squash and merge this PR after your CI passes on it
+- \`@dependabot cancel merge\` will cancel a previously requested merge and block automerging
+- \`@dependabot reopen\` will reopen this PR if it is closed
+- \`@dependabot close\` will close this PR and stop Dependabot recreating it. You can achieve the same result by closing it manually
+- \`@dependabot show <dependency name> ignore conditions\` will show all of the ignore conditions of the specified dependency
+- \`@dependabot ignore this major version\` will close this PR and stop Dependabot creating any more for this major version (unless you reopen the PR or upgrade to it yourself)
+- \`@dependabot ignore this minor version\` will close this PR and stop Dependabot creating any more for this minor version (unless you reopen the PR or upgrade to it yourself)
+- \`@dependabot ignore this dependency\` will close this PR and stop Dependabot creating any more for this dependency (unless you reopen the PR or upgrade to it yourself)
+You can disable automated security fix PRs for this repo from the [Security Alerts page](https://github.com/quantizor/markdown-to-jsx/network/alerts).
+
 </details>`;
 
 		mockOctokit.rest.pulls.get.mockImplementation(() => Promise.resolve({
 			data: {
-				title: 'Bump @auth/sveltekit from 0.3.11 to 0.3.12',
+				title: 'Bump nanoid from 3.3.6 to 3.3.8',
 				body: mockPRBody,
 			},
 			status: 200
@@ -85,7 +133,242 @@ describe('run', () => {
 		const hasChangelog = writeFileCalls.some((call) => {
 			const content = call[1] as string;
 			return content.includes('<details>') &&
-				content.includes('Release notes');
+				content.includes('Changelog') && content.includes('Commits');
+		});
+		expect(hasChangelog).toBe(true);
+	});
+
+	it('extracts changelog for grouped-package PRs when include-changelog is true', async () => {
+		// Mock PR response with changelog
+		const mockPRBody = `
+Bumps the all group with 3 updates: [@playwright/test](https://github.com/microsoft/playwright), [svelte](https://github.com/sveltejs/svelte/tree/HEAD/packages/svelte) and [wrangler](https://github.com/cloudflare/workers-sdk/tree/HEAD/packages/wrangler).
+
+Updates \`@playwright/test\` from 1.39.0 to 1.40.0
+<details>
+<summary>Release notes</summary>
+<p><em>Sourced from <a href="https://github.com/microsoft/playwright/releases"><code>@​playwright/test</code>'s releases</a>.</em></p>
+<blockquote>
+<h2>v1.40.0</h2>
+<h2>Test Generator Update</h2>
+<p><img src="https://github.com/microsoft/playwright/assets/9881434/e8d67e2e-f36d-4301-8631-023948d3e190" alt="Playwright Test Generator" /></p>
+<p>New tools to generate assertions:</p>
+<ul>
+<li>&quot;Assert visibility&quot; tool generates <a href="https://playwright.dev/docs/api/class-locatorassertions#locator-assertions-to-be-visible">expect(locator).toBeVisible()</a>.</li>
+<li>&quot;Assert value&quot; tool generates <a href="https://playwright.dev/docs/api/class-locatorassertions#locator-assertions-to-have-value">expect(locator).toHaveValue(value)</a>.</li>
+<li>&quot;Assert text&quot; tool generates <a href="https://playwright.dev/docs/api/class-locatorassertions#locator-assertions-to-contain-text">expect(locator).toContainText(text)</a>.</li>
+</ul>
+<p>Here is an example of a generated test with assertions:</p>
+<pre lang="js"><code>import { test, expect } from '@playwright/test';
+<p>test('test', async ({ page }) =&gt; {
+await page.goto('<a href="https://playwright.dev/">https://playwright.dev/</a>');
+await page.getByRole('link', { name: 'Get started' }).click();
+await expect(page.getByLabel('Breadcrumbs').getByRole('list')).toContainText('Installation');
+await expect(page.getByLabel('Search')).toBeVisible();
+await page.getByLabel('Search').click();
+await page.getByPlaceholder('Search docs').fill('locator');
+await expect(page.getByPlaceholder('Search docs')).toHaveValue('locator');
+});
+</code></pre></p>
+<h2>New APIs</h2>
+<ul>
+<li>Option <code>reason</code> in <a href="https://playwright.dev/docs/api/class-page#page-close">page.close()</a>, <a href="https://playwright.dev/docs/api/class-browsercontext#browser-context-close">browserContext.close()</a> and <a href="https://playwright.dev/docs/api/class-browser#browser-close">browser.close()</a>. Close reason is reported for all operations interrupted by the closure.</li>
+<li>Option <code>firefoxUserPrefs</code> in <a href="https://playwright.dev/docs/api/class-browsertype#browser-type-launch-persistent-context">browserType.launchPersistentContext(userDataDir)</a>.</li>
+</ul>
+<h2>Other Changes</h2>
+<ul>
+<li>Methods <a href="https://playwright.dev/docs/api/class-download#download-path">download.path()</a> and <a href="https://playwright.dev/docs/api/class-download#download-create-read-stream">download.createReadStream()</a> throw an error for failed and cancelled downloads.</li>
+<li>Playwright <a href="https://playwright.dev/docs/docker">docker image</a> now comes with Node.js v20.</li>
+</ul>
+<h2>Browser Versions</h2>
+<ul>
+<li>Chromium 120.0.6099.28</li>
+<li>Mozilla Firefox 119.0</li>
+<li>WebKit 17.4</li>
+</ul>
+<p>This version was also tested against the following stable channels:</p>
+<ul>
+<li>Google Chrome 119</li>
+<li>Microsoft Edge 119</li>
+</ul>
+</blockquote>
+</details>
+<details>
+<summary>Commits</summary>
+<ul>
+<li><a href="https://github.com/microsoft/playwright/commit/b8949166dc08e0ae499d08bec004a3f1a4e26ec8"><code>b894916</code></a> cherry-pick(<a href="https://redirect.github.com/microsoft/playwright/issues/28198">#28198</a>): feat(recorder): UX updates for assertion tools (<a href="https://redirect.github.com/microsoft/playwright/issues/28202">#28202</a>)</li>
+<li><a href="https://github.com/microsoft/playwright/commit/59e8f4815ddc99b53b3856805c83841ad5586eab"><code>59e8f48</code></a> chore: mark v1.40.0 (<a href="https://redirect.github.com/microsoft/playwright/issues/28199">#28199</a>)</li>
+<li><a href="https://github.com/microsoft/playwright/commit/85438edb97772d501443eaf5deaeab9f064b2045"><code>85438ed</code></a> test: Intl.ListFormat is working in playwright all browsers (<a href="https://redirect.github.com/microsoft/playwright/issues/28178">#28178</a>)</li>
+<li><a href="https://github.com/microsoft/playwright/commit/aec4399d8f97e06470859e50e2acf81efe748d64"><code>aec4399</code></a> docs: release notes for v1.40 (<a href="https://redirect.github.com/microsoft/playwright/issues/28175">#28175</a>)</li>
+<li><a href="https://github.com/microsoft/playwright/commit/25b9c4eb4ae7aac078cecb731faaa32128c57c8a"><code>25b9c4e</code></a> chore: do not lose error name for js errors (<a href="https://redirect.github.com/microsoft/playwright/issues/28177">#28177</a>)</li>
+<li><a href="https://github.com/microsoft/playwright/commit/4575c9a182b72df4d6720690ebe5b4911d240a45"><code>4575c9a</code></a> chore(logs): Add new log level to capture client-server message's metadata in...</li>
+<li><a href="https://github.com/microsoft/playwright/commit/80bab8afae12603e9a8ed6a094cf7a7317e51a45"><code>80bab8a</code></a> fix(electron/android): re-add Element.prototype.checkVisibility check (<a href="https://redirect.github.com/microsoft/playwright/issues/28173">#28173</a>)</li>
+<li><a href="https://github.com/microsoft/playwright/commit/7ffcb42551d920a4733e37f1b16bb0441996bb92"><code>7ffcb42</code></a> test: fix 'exposeFunction should not leak' in video mode (<a href="https://redirect.github.com/microsoft/playwright/issues/28169">#28169</a>)</li>
+<li><a href="https://github.com/microsoft/playwright/commit/0867c3ce5b2f7563c99f279d433885d8ec8423d9"><code>0867c3c</code></a> feat(chromium): roll to r1091 (<a href="https://redirect.github.com/microsoft/playwright/issues/28171">#28171</a>)</li>
+<li><a href="https://github.com/microsoft/playwright/commit/1c8ceb0a029533c7c05b20176aaffd41eb6f65bb"><code>1c8ceb0</code></a> fix(html-reporter): Include specified host and port in the logged instruction...</li>
+<li>Additional commits viewable in <a href="https://github.com/microsoft/playwright/compare/v1.39.0...v1.40.0">compare view</a></li>
+</ul>
+</details>
+<details>
+<summary>Maintainer changes</summary>
+<p>This version was pushed to npm by <a href="https://www.npmjs.com/~dgozman-ms">dgozman-ms</a>, a new releaser for <code>@​playwright/test</code> since your current version.</p>
+</details>
+<br />
+
+Updates \`svelte\` from 4.2.3 to 4.2.4
+<details>
+<summary>Release notes</summary>
+<p><em>Sourced from <a href="https://github.com/sveltejs/svelte/releases">svelte's releases</a>.</em></p>
+<blockquote>
+<h2>svelte@4.2.4</h2>
+<h3>Patch Changes</h3>
+<ul>
+<li>fix: handle closing tags inside attribute values (<a href="https://redirect.github.com/sveltejs/svelte/pull/9486">#9486</a>)</li>
+</ul>
+</blockquote>
+</details>
+<details>
+<summary>Changelog</summary>
+<p><em>Sourced from <a href="https://github.com/sveltejs/svelte/blob/svelte@4.2.4/packages/svelte/CHANGELOG.md">svelte's changelog</a>.</em></p>
+<blockquote>
+<h2>4.2.4</h2>
+<h3>Patch Changes</h3>
+<ul>
+<li>fix: handle closing tags inside attribute values (<a href="https://redirect.github.com/sveltejs/svelte/pull/9486">#9486</a>)</li>
+</ul>
+</blockquote>
+</details>
+<details>
+<summary>Commits</summary>
+<ul>
+<li><a href="https://github.com/sveltejs/svelte/commit/2ea17648f236724c46590d596048ebfaa29ef21f"><code>2ea1764</code></a> Version Packages (<a href="https://github.com/sveltejs/svelte/tree/HEAD/packages/svelte/issues/9491">#9491</a>)</li>
+<li><a href="https://github.com/sveltejs/svelte/commit/b2e1f1c1029bd059961a50d51e4da8f2e741a9d7"><code>b2e1f1c</code></a> fix: handle closing tags inside attribute values (<a href="https://github.com/sveltejs/svelte/tree/HEAD/packages/svelte/issues/9486">#9486</a>)</li>
+<li>See full diff in <a href="https://github.com/sveltejs/svelte/commits/svelte@4.2.4/packages/svelte">compare view</a></li>
+</ul>
+</details>
+<br />
+
+Updates \`wrangler\` from 3.15.0 to 3.16.0
+<details>
+<summary>Changelog</summary>
+<p><em>Sourced from <a href="https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/CHANGELOG.md">wrangler's changelog</a>.</em></p>
+<blockquote>
+<h2>3.16.0</h2>
+<h3>Minor Changes</h3>
+<ul>
+<li><a href="https://redirect.github.com/cloudflare/workers-sdk/pull/4347">#4347</a> <a href="https://github.com/cloudflare/workers-sdk/commit/102e15f9e735ff7506cfff457046137ee7b03c32"><code>102e15f9</code></a> Thanks <a href="https://github.com/Skye-31"><code>@​Skye-31</code></a>! - Feat(unstable_dev): Provide an option for unstable_dev to perform the check that prompts users to update wrangler, defaulting to false. This will prevent unstable_dev from sending a request to NPM on startup to determine whether it needs to be updated.</li>
+</ul>
+<ul>
+<li>
+<p><a href="https://redirect.github.com/cloudflare/workers-sdk/pull/4179">#4179</a> <a href="https://github.com/cloudflare/workers-sdk/commit/dd270d0065159150ff318f2f06607ddecba6ee9b"><code>dd270d00</code></a> Thanks <a href="https://github.com/matthewdavidrodgers"><code>@​matthewdavidrodgers</code></a>! - Simplify secret:bulk api via script settings</p>
+<p>Firing PUTs to the secret api in parallel has never been a great solution - each request independently needs to lock the script, so running in parallel is at best just as bad as running serially.</p>
+<p>Luckily, we have the script settings PATCH api now, which can update the settings for a script (including secret bindings) at once, which means we don't need any parallelization. However this api doesn't work with a partial list of bindings, so we have to fetch the current bindings and merge in with the new secrets before PATCHing. We can however just omit the value of the binding (i.e. only provide the name and type) which instructs the config service to inherit the existing value, which simplifies this as well. Note that we don't use the bindings in your current wrangler.toml, as you could be in a draft state, and it makes sense as a user that a bulk secrets update won't update anything else. Instead, we use script settings api again to fetch the current state of your bindings.</p>
+<p>This simplified implementation means the operation can only fail or succeed, rather than succeeding in updating some secrets but failing for others. In order to not introduce breaking changes for logging output, the language around &quot;\${x} secrets were updated&quot; or &quot;\${x} secrets failed&quot; is kept, even if it doesn't make much sense anymore.</p>
+</li>
+</ul>
+<h3>Patch Changes</h3>
+<ul>
+<li>
+<p><a href="https://redirect.github.com/cloudflare/workers-sdk/pull/4402">#4402</a> <a href="https://github.com/cloudflare/workers-sdk/commit/baa76e774038393fb6b491e2c371da53b8b2a676"><code>baa76e77</code></a> Thanks <a href="https://github.com/rozenmd"><code>@​rozenmd</code></a>! - This PR adds a fetch handler that uses <code>page</code>, assuming <code>result_info</code> provided by the endpoint contains <code>page</code>, <code>per_page</code>, and <code>total</code></p>
+<p>This is needed as the existing <code>fetchListResult</code> handler for fetching potentially paginated results doesn't work for endpoints that don't implement <code>cursor</code>.</p>
+<p>Fixes <a href="https://github.com/cloudflare/workers-sdk/tree/HEAD/packages/wrangler/issues/4349">#4349</a></p>
+</li>
+</ul>
+<ul>
+<li>
+<p><a href="https://redirect.github.com/cloudflare/workers-sdk/pull/4337">#4337</a> <a href="https://github.com/cloudflare/workers-sdk/commit/6c8f41f8e76890d6027fd97eaf4e88dccb509fc8"><code>6c8f41f8</code></a> Thanks <a href="https://github.com/Skye-31"><code>@​Skye-31</code></a>! - Improve the error message when a script isn't exported a Durable Object class</p>
+<p>Previously, wrangler would error with a message like <code>Uncaught TypeError: Class extends value undefined is not a constructor or null</code>. This improves that messaging to be more understandable to users.</p>
+</li>
+</ul>
+<ul>
+<li><a href="https://redirect.github.com/cloudflare/workers-sdk/pull/4307">#4307</a> <a href="https://github.com/cloudflare/workers-sdk/commit/7fbe1937b311f36077c92814207bbb15ef3878d6"><code>7fbe1937</code></a> Thanks <a href="https://github.com/jspspike"><code>@​jspspike</code></a>! - Change local dev server default ip to <code>*</code> instead of <code>0.0.0.0</code>. This will cause the dev server to listen on both ipv4 and ipv6 interfaces</li>
+</ul>
+<ul>
+<li><a href="https://redirect.github.com/cloudflare/workers-sdk/pull/4222">#4222</a> <a href="https://github.com/cloudflare/workers-sdk/commit/f867e01ca2967a11a8d5eda32da42941383753a8"><code>f867e01c</code></a> Thanks <a href="https://github.com/tmthecoder"><code>@​tmthecoder</code></a>! - Support for hyperdrive bindings in local wrangler dev</li>
+</ul>
+<ul>
+<li><a href="https://redirect.github.com/cloudflare/workers-sdk/pull/4149">#4149</a> <a href="https://github.com/cloudflare/workers-sdk/commit/7e05f38e04e40125c9c5352b7ff1c95616c1baf0"><code>7e05f38e</code></a> Thanks <a href="https://github.com/jspspike"><code>@​jspspike</code></a>! - Fixed issue with <code>tail</code> not using proxy</li>
+</ul>
+<ul>
+<li><a href="https://redirect.github.com/cloudflare/workers-sdk/pull/4219">#4219</a> <a href="https://github.com/cloudflare/workers-sdk/commit/0453b447251cc670310be6a2067c84074f6a515b"><code>0453b447</code></a> Thanks <a href="https://github.com/maxwellpeterson"><code>@​maxwellpeterson</code></a>! - Allows uploads with both cron triggers and smart placement enabled</li>
+</ul>
+<ul>
+<li>
+<p><a href="https://redirect.github.com/cloudflare/workers-sdk/pull/4437">#4437</a> <a href="https://github.com/cloudflare/workers-sdk/commit/05b1bbd2f5b8e60268e30c276067c3a3ae1239cf"><code>05b1bbd2</code></a> Thanks <a href="https://github.com/jspspike"><code>@​jspspike</code></a>! - Change dev registry and inspector server to listen on 127.0.0.1 instead of all interfaces</p>
+</li>
+<li>
+<p>Updated dependencies [<a href="https://github.com/cloudflare/workers-sdk/commit/4f8b3420f93197d331491f012ff6f4626411bfc5"><code>4f8b3420</code></a>, <a href="https://github.com/cloudflare/workers-sdk/commit/16cc2e923733b3c583b5bf6c40384c52fea04991"><code>16cc2e92</code></a>, <a href="https://github.com/cloudflare/workers-sdk/commit/3637d97a99c9d5e8d0d2b5f3adaf4bd9993265f0"><code>3637d97a</code></a>, <a href="https://github.com/cloudflare/workers-sdk/commit/29a59d4e72e3ae849474325c5c93252a3f84af0d"><code>29a59d4e</code></a>, <a href="https://github.com/cloudflare/workers-sdk/commit/7fbe1937b311f36077c92814207bbb15ef3878d6"><code>7fbe1937</code></a>, <a href="https://github.com/cloudflare/workers-sdk/commit/767878613eda535d125539a478d488d1a42feaa1"><code>76787861</code></a>, <a href="https://github.com/cloudflare/workers-sdk/commit/8a25b7fba94c8e9989412bc266ada307975f182d"><code>8a25b7fb</code></a>]:</p>
+<ul>
+<li>miniflare@3.20231030.0</li>
+</ul>
+</li>
+</ul>
+</blockquote>
+</details>
+<details>
+<summary>Commits</summary>
+<ul>
+<li>See full diff in <a href="https://github.com/cloudflare/workers-sdk/commits/HEAD/packages/wrangler">compare view</a></li>
+</ul>
+</details>
+<br />
+
+
+Dependabot will resolve any conflicts with this PR as long as you don't alter it yourself. You can also trigger a rebase manually by commenting \`@dependabot rebase\`.
+
+[//]: # (dependabot-automerge-start)
+[//]: # (dependabot-automerge-end)
+
+---
+
+<details>
+<summary>Dependabot commands and options</summary>
+<br />
+
+You can trigger Dependabot actions by commenting on this PR:
+- \`@dependabot rebase\` will rebase this PR
+- \`@dependabot recreate\` will recreate this PR, overwriting any edits that have been made to it
+- \`@dependabot merge\` will merge this PR after your CI passes on it
+- \`@dependabot squash and merge\` will squash and merge this PR after your CI passes on it
+- \`@dependabot cancel merge\` will cancel a previously requested merge and block automerging
+- \`@dependabot reopen\` will reopen this PR if it is closed
+- \`@dependabot close\` will close this PR and stop Dependabot recreating it. You can achieve the same result by closing it manually
+- \`@dependabot show <dependency name> ignore conditions\` will show all of the ignore conditions of the specified dependency
+- \`@dependabot ignore <dependency name> major version\` will close this group update PR and stop Dependabot creating any more for the specific dependency's major version (unless you unignore this specific dependency's major version or upgrade to it yourself)
+- \`@dependabot ignore <dependency name> minor version\` will close this group update PR and stop Dependabot creating any more for the specific dependency's minor version (unless you unignore this specific dependency's minor version or upgrade to it yourself)
+- \`@dependabot ignore <dependency name>\` will close this group update PR and stop Dependabot creating any more for the specific dependency (unless you unignore this specific dependency or upgrade to it yourself)
+- \`@dependabot unignore <dependency name>\` will remove all of the ignore conditions of the specified dependency
+- \`@dependabot unignore <dependency name> <ignore condition>\` will remove the ignore condition of the specified dependency and ignore conditions
+
+
+</details>
+`;
+
+		mockOctokit.rest.pulls.get.mockImplementation(() => Promise.resolve({
+			data: {
+				title: 'Bump the cloudflare group',
+				body: mockPRBody,
+			},
+			status: 200
+		}));
+
+		// Mock include-changelog input as true
+		(core.getInput as jest.Mock).mockImplementation((name) => {
+			switch (name) {
+				case 'include-changelog':
+					return 'true';
+				default:
+					return '';
+			}
+		});
+
+		await run();
+
+		// Verify that writeFile was called with content containing changelog
+		const writeFileCalls = (writeFile as jest.Mock).mock.calls;
+		const hasChangelog = writeFileCalls.some((call) => {
+			const content = call[1] as string;
+			return content.includes('<details>') &&
+				content.includes('Changelog') && content.includes('Commits');
 		});
 		expect(hasChangelog).toBe(true);
 	});

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
-import { readFile, writeFile } from 'fs/promises';
+import * as fs from 'fs/promises';
 import { run } from '../src/main';
 import { jest } from '@jest/globals';
 
@@ -20,12 +20,19 @@ describe('run', () => {
 		},
 	};
 
+	let fsActual: typeof fs;
+
 	beforeEach(() => {
 		// Reset all mocks
 		jest.resetAllMocks();
+
+		fsActual = jest.requireActual('fs/promises');
+
 		(github.getOctokit as jest.Mock).mockReturnValue(mockOctokit);
-		(readFile as jest.Mock).mockImplementation(() => Promise.resolve('mock file content'));
-		(writeFile as jest.Mock).mockImplementation(() => Promise.resolve());
+
+		(fs.readFile as jest.Mock).mockImplementation(() => Promise.resolve('mock file content'));
+
+		(fs.writeFile as jest.Mock).mockImplementation(() => Promise.resolve());
 
 		// Mock core.getInput for required inputs
 		(core.getInput as jest.Mock).mockImplementation((name) => {
@@ -46,67 +53,7 @@ describe('run', () => {
 
 	it('extracts changelog for single package PR when include-changelog is true', async () => {
 		// Mock PR response with changelog
-		const mockPRBody = `
-Bumps [nanoid](https://github.com/ai/nanoid) from 3.3.6 to 3.3.8.
-<details>
-<summary>Changelog</summary>
-<p><em>Sourced from <a href="https://github.com/ai/nanoid/blob/main/CHANGELOG.md">nanoid's changelog</a>.</em></p>
-<blockquote>
-<h2>3.3.8</h2>
-<ul>
-<li>Fixed a way to break Nano ID by passing non-integer size (by <a href="https://github.com/myndzi"><code>@​myndzi</code></a>).</li>
-</ul>
-<h2>3.3.7</h2>
-<ul>
-<li>Fixed <code>node16</code> TypeScript support (by Saadi Myftija).</li>
-</ul>
-</blockquote>
-</details>
-<details>
-<summary>Commits</summary>
-<ul>
-<li><a href="https://github.com/ai/nanoid/commit/3044cd5e73f4cf31795f61f6e6b961c8c0a5c744"><code>3044cd5</code></a> Release 3.3.8 version</li>
-<li><a href="https://github.com/ai/nanoid/commit/4fe34959c34e5b3573889ed4f24fe91d1d3e7231"><code>4fe3495</code></a> Update size limit</li>
-<li><a href="https://github.com/ai/nanoid/commit/d643045f40d6dc8afa000a644d857da1436ed08c"><code>d643045</code></a> Fix pool pollution, infinite loop (<a href="https://redirect.github.com/ai/nanoid/issues/510">#510</a>)</li>
-<li><a href="https://github.com/ai/nanoid/commit/89d82d2ce4b0411e73ac7ccfe57bc03e932416e2"><code>89d82d2</code></a> Release 3.3.7 version</li>
-<li><a href="https://github.com/ai/nanoid/commit/5022c35acaaedd9da4b56cad37b02bbcb87635e1"><code>5022c35</code></a> Update dual-publish</li>
-<li><a href="https://github.com/ai/nanoid/commit/3e7a8e557b9d93a582ef2c3bb9f7306fc339ef35"><code>3e7a8e5</code></a> Remove benchmark from CI for v3</li>
-<li><a href="https://github.com/ai/nanoid/commit/d3561446aee52fdf38325e1d30c905d989a8ccd2"><code>d356144</code></a> Fix CI for v3</li>
-<li><a href="https://github.com/ai/nanoid/commit/37b25dfac2edfd73d7bbc88886e4c6067fac8619"><code>37b25df</code></a> Move to pnpm 8</li>
-<li>See full diff in <a href="https://github.com/ai/nanoid/compare/3.3.6...3.3.8">compare view</a></li>
-</ul>
-</details>
-<br />
-
-
-[![Dependabot compatibility score](https://dependabot-badges.githubapp.com/badges/compatibility_score?dependency-name=nanoid&package-manager=npm_and_yarn&previous-version=3.3.6&new-version=3.3.8)](https://docs.github.com/en/github/managing-security-vulnerabilities/about-dependabot-security-updates#about-compatibility-scores)
-
-Dependabot will resolve any conflicts with this PR as long as you don't alter it yourself. You can also trigger a rebase manually by commenting \`@dependabot rebase\`.
-
-[//]: # (dependabot-automerge-start)
-[//]: # (dependabot-automerge-end)
-
----
-
-<details>
-<summary>Dependabot commands and options</summary>
-<br />
-
-You can trigger Dependabot actions by commenting on this PR:
-- \`@dependabot rebase\` will rebase this PR
-- \`@dependabot recreate\` will recreate this PR, overwriting any edits that have been made to it
-- \`@dependabot merge\` will merge this PR after your CI passes on it
-- \`@dependabot squash and merge\` will squash and merge this PR after your CI passes on it
-- \`@dependabot cancel merge\` will cancel a previously requested merge and block automerging
-- \`@dependabot reopen\` will reopen this PR if it is closed
-- \`@dependabot close\` will close this PR and stop Dependabot recreating it. You can achieve the same result by closing it manually
-- \`@dependabot show <dependency name> ignore conditions\` will show all of the ignore conditions of the specified dependency
-- \`@dependabot ignore this major version\` will close this PR and stop Dependabot creating any more for this major version (unless you reopen the PR or upgrade to it yourself)
-- \`@dependabot ignore this minor version\` will close this PR and stop Dependabot creating any more for this minor version (unless you reopen the PR or upgrade to it yourself)
-- \`@dependabot ignore this dependency\` will close this PR and stop Dependabot creating any more for this dependency (unless you reopen the PR or upgrade to it yourself)
-You can disable automated security fix PRs for this repo from the [Security Alerts page](https://github.com/quantizor/markdown-to-jsx/network/alerts).
-
-</details>`;
+		const mockPRBody = await fsActual.readFile(__dirname + '/single-pr-body.txt', 'utf-8');
 
 		mockOctokit.rest.pulls.get.mockImplementation(() => Promise.resolve({
 			data: {
@@ -129,7 +76,7 @@ You can disable automated security fix PRs for this repo from the [Security Aler
 		await run();
 
 		// Verify that writeFile was called with content containing changelog
-		const writeFileCalls = (writeFile as jest.Mock).mock.calls;
+		const writeFileCalls = (fs.writeFile as jest.Mock).mock.calls;
 		const hasChangelog = writeFileCalls.some((call) => {
 			const content = call[1] as string;
 			return content.includes('<details>') &&
@@ -140,208 +87,7 @@ You can disable automated security fix PRs for this repo from the [Security Aler
 
 	it('extracts changelog for grouped-package PRs when include-changelog is true', async () => {
 		// Mock PR response with changelog
-		const mockPRBody = `
-Bumps the all group with 3 updates: [@playwright/test](https://github.com/microsoft/playwright), [svelte](https://github.com/sveltejs/svelte/tree/HEAD/packages/svelte) and [wrangler](https://github.com/cloudflare/workers-sdk/tree/HEAD/packages/wrangler).
-
-Updates \`@playwright/test\` from 1.39.0 to 1.40.0
-<details>
-<summary>Release notes</summary>
-<p><em>Sourced from <a href="https://github.com/microsoft/playwright/releases"><code>@​playwright/test</code>'s releases</a>.</em></p>
-<blockquote>
-<h2>v1.40.0</h2>
-<h2>Test Generator Update</h2>
-<p><img src="https://github.com/microsoft/playwright/assets/9881434/e8d67e2e-f36d-4301-8631-023948d3e190" alt="Playwright Test Generator" /></p>
-<p>New tools to generate assertions:</p>
-<ul>
-<li>&quot;Assert visibility&quot; tool generates <a href="https://playwright.dev/docs/api/class-locatorassertions#locator-assertions-to-be-visible">expect(locator).toBeVisible()</a>.</li>
-<li>&quot;Assert value&quot; tool generates <a href="https://playwright.dev/docs/api/class-locatorassertions#locator-assertions-to-have-value">expect(locator).toHaveValue(value)</a>.</li>
-<li>&quot;Assert text&quot; tool generates <a href="https://playwright.dev/docs/api/class-locatorassertions#locator-assertions-to-contain-text">expect(locator).toContainText(text)</a>.</li>
-</ul>
-<p>Here is an example of a generated test with assertions:</p>
-<pre lang="js"><code>import { test, expect } from '@playwright/test';
-<p>test('test', async ({ page }) =&gt; {
-await page.goto('<a href="https://playwright.dev/">https://playwright.dev/</a>');
-await page.getByRole('link', { name: 'Get started' }).click();
-await expect(page.getByLabel('Breadcrumbs').getByRole('list')).toContainText('Installation');
-await expect(page.getByLabel('Search')).toBeVisible();
-await page.getByLabel('Search').click();
-await page.getByPlaceholder('Search docs').fill('locator');
-await expect(page.getByPlaceholder('Search docs')).toHaveValue('locator');
-});
-</code></pre></p>
-<h2>New APIs</h2>
-<ul>
-<li>Option <code>reason</code> in <a href="https://playwright.dev/docs/api/class-page#page-close">page.close()</a>, <a href="https://playwright.dev/docs/api/class-browsercontext#browser-context-close">browserContext.close()</a> and <a href="https://playwright.dev/docs/api/class-browser#browser-close">browser.close()</a>. Close reason is reported for all operations interrupted by the closure.</li>
-<li>Option <code>firefoxUserPrefs</code> in <a href="https://playwright.dev/docs/api/class-browsertype#browser-type-launch-persistent-context">browserType.launchPersistentContext(userDataDir)</a>.</li>
-</ul>
-<h2>Other Changes</h2>
-<ul>
-<li>Methods <a href="https://playwright.dev/docs/api/class-download#download-path">download.path()</a> and <a href="https://playwright.dev/docs/api/class-download#download-create-read-stream">download.createReadStream()</a> throw an error for failed and cancelled downloads.</li>
-<li>Playwright <a href="https://playwright.dev/docs/docker">docker image</a> now comes with Node.js v20.</li>
-</ul>
-<h2>Browser Versions</h2>
-<ul>
-<li>Chromium 120.0.6099.28</li>
-<li>Mozilla Firefox 119.0</li>
-<li>WebKit 17.4</li>
-</ul>
-<p>This version was also tested against the following stable channels:</p>
-<ul>
-<li>Google Chrome 119</li>
-<li>Microsoft Edge 119</li>
-</ul>
-</blockquote>
-</details>
-<details>
-<summary>Commits</summary>
-<ul>
-<li><a href="https://github.com/microsoft/playwright/commit/b8949166dc08e0ae499d08bec004a3f1a4e26ec8"><code>b894916</code></a> cherry-pick(<a href="https://redirect.github.com/microsoft/playwright/issues/28198">#28198</a>): feat(recorder): UX updates for assertion tools (<a href="https://redirect.github.com/microsoft/playwright/issues/28202">#28202</a>)</li>
-<li><a href="https://github.com/microsoft/playwright/commit/59e8f4815ddc99b53b3856805c83841ad5586eab"><code>59e8f48</code></a> chore: mark v1.40.0 (<a href="https://redirect.github.com/microsoft/playwright/issues/28199">#28199</a>)</li>
-<li><a href="https://github.com/microsoft/playwright/commit/85438edb97772d501443eaf5deaeab9f064b2045"><code>85438ed</code></a> test: Intl.ListFormat is working in playwright all browsers (<a href="https://redirect.github.com/microsoft/playwright/issues/28178">#28178</a>)</li>
-<li><a href="https://github.com/microsoft/playwright/commit/aec4399d8f97e06470859e50e2acf81efe748d64"><code>aec4399</code></a> docs: release notes for v1.40 (<a href="https://redirect.github.com/microsoft/playwright/issues/28175">#28175</a>)</li>
-<li><a href="https://github.com/microsoft/playwright/commit/25b9c4eb4ae7aac078cecb731faaa32128c57c8a"><code>25b9c4e</code></a> chore: do not lose error name for js errors (<a href="https://redirect.github.com/microsoft/playwright/issues/28177">#28177</a>)</li>
-<li><a href="https://github.com/microsoft/playwright/commit/4575c9a182b72df4d6720690ebe5b4911d240a45"><code>4575c9a</code></a> chore(logs): Add new log level to capture client-server message's metadata in...</li>
-<li><a href="https://github.com/microsoft/playwright/commit/80bab8afae12603e9a8ed6a094cf7a7317e51a45"><code>80bab8a</code></a> fix(electron/android): re-add Element.prototype.checkVisibility check (<a href="https://redirect.github.com/microsoft/playwright/issues/28173">#28173</a>)</li>
-<li><a href="https://github.com/microsoft/playwright/commit/7ffcb42551d920a4733e37f1b16bb0441996bb92"><code>7ffcb42</code></a> test: fix 'exposeFunction should not leak' in video mode (<a href="https://redirect.github.com/microsoft/playwright/issues/28169">#28169</a>)</li>
-<li><a href="https://github.com/microsoft/playwright/commit/0867c3ce5b2f7563c99f279d433885d8ec8423d9"><code>0867c3c</code></a> feat(chromium): roll to r1091 (<a href="https://redirect.github.com/microsoft/playwright/issues/28171">#28171</a>)</li>
-<li><a href="https://github.com/microsoft/playwright/commit/1c8ceb0a029533c7c05b20176aaffd41eb6f65bb"><code>1c8ceb0</code></a> fix(html-reporter): Include specified host and port in the logged instruction...</li>
-<li>Additional commits viewable in <a href="https://github.com/microsoft/playwright/compare/v1.39.0...v1.40.0">compare view</a></li>
-</ul>
-</details>
-<details>
-<summary>Maintainer changes</summary>
-<p>This version was pushed to npm by <a href="https://www.npmjs.com/~dgozman-ms">dgozman-ms</a>, a new releaser for <code>@​playwright/test</code> since your current version.</p>
-</details>
-<br />
-
-Updates \`svelte\` from 4.2.3 to 4.2.4
-<details>
-<summary>Release notes</summary>
-<p><em>Sourced from <a href="https://github.com/sveltejs/svelte/releases">svelte's releases</a>.</em></p>
-<blockquote>
-<h2>svelte@4.2.4</h2>
-<h3>Patch Changes</h3>
-<ul>
-<li>fix: handle closing tags inside attribute values (<a href="https://redirect.github.com/sveltejs/svelte/pull/9486">#9486</a>)</li>
-</ul>
-</blockquote>
-</details>
-<details>
-<summary>Changelog</summary>
-<p><em>Sourced from <a href="https://github.com/sveltejs/svelte/blob/svelte@4.2.4/packages/svelte/CHANGELOG.md">svelte's changelog</a>.</em></p>
-<blockquote>
-<h2>4.2.4</h2>
-<h3>Patch Changes</h3>
-<ul>
-<li>fix: handle closing tags inside attribute values (<a href="https://redirect.github.com/sveltejs/svelte/pull/9486">#9486</a>)</li>
-</ul>
-</blockquote>
-</details>
-<details>
-<summary>Commits</summary>
-<ul>
-<li><a href="https://github.com/sveltejs/svelte/commit/2ea17648f236724c46590d596048ebfaa29ef21f"><code>2ea1764</code></a> Version Packages (<a href="https://github.com/sveltejs/svelte/tree/HEAD/packages/svelte/issues/9491">#9491</a>)</li>
-<li><a href="https://github.com/sveltejs/svelte/commit/b2e1f1c1029bd059961a50d51e4da8f2e741a9d7"><code>b2e1f1c</code></a> fix: handle closing tags inside attribute values (<a href="https://github.com/sveltejs/svelte/tree/HEAD/packages/svelte/issues/9486">#9486</a>)</li>
-<li>See full diff in <a href="https://github.com/sveltejs/svelte/commits/svelte@4.2.4/packages/svelte">compare view</a></li>
-</ul>
-</details>
-<br />
-
-Updates \`wrangler\` from 3.15.0 to 3.16.0
-<details>
-<summary>Changelog</summary>
-<p><em>Sourced from <a href="https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/CHANGELOG.md">wrangler's changelog</a>.</em></p>
-<blockquote>
-<h2>3.16.0</h2>
-<h3>Minor Changes</h3>
-<ul>
-<li><a href="https://redirect.github.com/cloudflare/workers-sdk/pull/4347">#4347</a> <a href="https://github.com/cloudflare/workers-sdk/commit/102e15f9e735ff7506cfff457046137ee7b03c32"><code>102e15f9</code></a> Thanks <a href="https://github.com/Skye-31"><code>@​Skye-31</code></a>! - Feat(unstable_dev): Provide an option for unstable_dev to perform the check that prompts users to update wrangler, defaulting to false. This will prevent unstable_dev from sending a request to NPM on startup to determine whether it needs to be updated.</li>
-</ul>
-<ul>
-<li>
-<p><a href="https://redirect.github.com/cloudflare/workers-sdk/pull/4179">#4179</a> <a href="https://github.com/cloudflare/workers-sdk/commit/dd270d0065159150ff318f2f06607ddecba6ee9b"><code>dd270d00</code></a> Thanks <a href="https://github.com/matthewdavidrodgers"><code>@​matthewdavidrodgers</code></a>! - Simplify secret:bulk api via script settings</p>
-<p>Firing PUTs to the secret api in parallel has never been a great solution - each request independently needs to lock the script, so running in parallel is at best just as bad as running serially.</p>
-<p>Luckily, we have the script settings PATCH api now, which can update the settings for a script (including secret bindings) at once, which means we don't need any parallelization. However this api doesn't work with a partial list of bindings, so we have to fetch the current bindings and merge in with the new secrets before PATCHing. We can however just omit the value of the binding (i.e. only provide the name and type) which instructs the config service to inherit the existing value, which simplifies this as well. Note that we don't use the bindings in your current wrangler.toml, as you could be in a draft state, and it makes sense as a user that a bulk secrets update won't update anything else. Instead, we use script settings api again to fetch the current state of your bindings.</p>
-<p>This simplified implementation means the operation can only fail or succeed, rather than succeeding in updating some secrets but failing for others. In order to not introduce breaking changes for logging output, the language around &quot;\${x} secrets were updated&quot; or &quot;\${x} secrets failed&quot; is kept, even if it doesn't make much sense anymore.</p>
-</li>
-</ul>
-<h3>Patch Changes</h3>
-<ul>
-<li>
-<p><a href="https://redirect.github.com/cloudflare/workers-sdk/pull/4402">#4402</a> <a href="https://github.com/cloudflare/workers-sdk/commit/baa76e774038393fb6b491e2c371da53b8b2a676"><code>baa76e77</code></a> Thanks <a href="https://github.com/rozenmd"><code>@​rozenmd</code></a>! - This PR adds a fetch handler that uses <code>page</code>, assuming <code>result_info</code> provided by the endpoint contains <code>page</code>, <code>per_page</code>, and <code>total</code></p>
-<p>This is needed as the existing <code>fetchListResult</code> handler for fetching potentially paginated results doesn't work for endpoints that don't implement <code>cursor</code>.</p>
-<p>Fixes <a href="https://github.com/cloudflare/workers-sdk/tree/HEAD/packages/wrangler/issues/4349">#4349</a></p>
-</li>
-</ul>
-<ul>
-<li>
-<p><a href="https://redirect.github.com/cloudflare/workers-sdk/pull/4337">#4337</a> <a href="https://github.com/cloudflare/workers-sdk/commit/6c8f41f8e76890d6027fd97eaf4e88dccb509fc8"><code>6c8f41f8</code></a> Thanks <a href="https://github.com/Skye-31"><code>@​Skye-31</code></a>! - Improve the error message when a script isn't exported a Durable Object class</p>
-<p>Previously, wrangler would error with a message like <code>Uncaught TypeError: Class extends value undefined is not a constructor or null</code>. This improves that messaging to be more understandable to users.</p>
-</li>
-</ul>
-<ul>
-<li><a href="https://redirect.github.com/cloudflare/workers-sdk/pull/4307">#4307</a> <a href="https://github.com/cloudflare/workers-sdk/commit/7fbe1937b311f36077c92814207bbb15ef3878d6"><code>7fbe1937</code></a> Thanks <a href="https://github.com/jspspike"><code>@​jspspike</code></a>! - Change local dev server default ip to <code>*</code> instead of <code>0.0.0.0</code>. This will cause the dev server to listen on both ipv4 and ipv6 interfaces</li>
-</ul>
-<ul>
-<li><a href="https://redirect.github.com/cloudflare/workers-sdk/pull/4222">#4222</a> <a href="https://github.com/cloudflare/workers-sdk/commit/f867e01ca2967a11a8d5eda32da42941383753a8"><code>f867e01c</code></a> Thanks <a href="https://github.com/tmthecoder"><code>@​tmthecoder</code></a>! - Support for hyperdrive bindings in local wrangler dev</li>
-</ul>
-<ul>
-<li><a href="https://redirect.github.com/cloudflare/workers-sdk/pull/4149">#4149</a> <a href="https://github.com/cloudflare/workers-sdk/commit/7e05f38e04e40125c9c5352b7ff1c95616c1baf0"><code>7e05f38e</code></a> Thanks <a href="https://github.com/jspspike"><code>@​jspspike</code></a>! - Fixed issue with <code>tail</code> not using proxy</li>
-</ul>
-<ul>
-<li><a href="https://redirect.github.com/cloudflare/workers-sdk/pull/4219">#4219</a> <a href="https://github.com/cloudflare/workers-sdk/commit/0453b447251cc670310be6a2067c84074f6a515b"><code>0453b447</code></a> Thanks <a href="https://github.com/maxwellpeterson"><code>@​maxwellpeterson</code></a>! - Allows uploads with both cron triggers and smart placement enabled</li>
-</ul>
-<ul>
-<li>
-<p><a href="https://redirect.github.com/cloudflare/workers-sdk/pull/4437">#4437</a> <a href="https://github.com/cloudflare/workers-sdk/commit/05b1bbd2f5b8e60268e30c276067c3a3ae1239cf"><code>05b1bbd2</code></a> Thanks <a href="https://github.com/jspspike"><code>@​jspspike</code></a>! - Change dev registry and inspector server to listen on 127.0.0.1 instead of all interfaces</p>
-</li>
-<li>
-<p>Updated dependencies [<a href="https://github.com/cloudflare/workers-sdk/commit/4f8b3420f93197d331491f012ff6f4626411bfc5"><code>4f8b3420</code></a>, <a href="https://github.com/cloudflare/workers-sdk/commit/16cc2e923733b3c583b5bf6c40384c52fea04991"><code>16cc2e92</code></a>, <a href="https://github.com/cloudflare/workers-sdk/commit/3637d97a99c9d5e8d0d2b5f3adaf4bd9993265f0"><code>3637d97a</code></a>, <a href="https://github.com/cloudflare/workers-sdk/commit/29a59d4e72e3ae849474325c5c93252a3f84af0d"><code>29a59d4e</code></a>, <a href="https://github.com/cloudflare/workers-sdk/commit/7fbe1937b311f36077c92814207bbb15ef3878d6"><code>7fbe1937</code></a>, <a href="https://github.com/cloudflare/workers-sdk/commit/767878613eda535d125539a478d488d1a42feaa1"><code>76787861</code></a>, <a href="https://github.com/cloudflare/workers-sdk/commit/8a25b7fba94c8e9989412bc266ada307975f182d"><code>8a25b7fb</code></a>]:</p>
-<ul>
-<li>miniflare@3.20231030.0</li>
-</ul>
-</li>
-</ul>
-</blockquote>
-</details>
-<details>
-<summary>Commits</summary>
-<ul>
-<li>See full diff in <a href="https://github.com/cloudflare/workers-sdk/commits/HEAD/packages/wrangler">compare view</a></li>
-</ul>
-</details>
-<br />
-
-
-Dependabot will resolve any conflicts with this PR as long as you don't alter it yourself. You can also trigger a rebase manually by commenting \`@dependabot rebase\`.
-
-[//]: # (dependabot-automerge-start)
-[//]: # (dependabot-automerge-end)
-
----
-
-<details>
-<summary>Dependabot commands and options</summary>
-<br />
-
-You can trigger Dependabot actions by commenting on this PR:
-- \`@dependabot rebase\` will rebase this PR
-- \`@dependabot recreate\` will recreate this PR, overwriting any edits that have been made to it
-- \`@dependabot merge\` will merge this PR after your CI passes on it
-- \`@dependabot squash and merge\` will squash and merge this PR after your CI passes on it
-- \`@dependabot cancel merge\` will cancel a previously requested merge and block automerging
-- \`@dependabot reopen\` will reopen this PR if it is closed
-- \`@dependabot close\` will close this PR and stop Dependabot recreating it. You can achieve the same result by closing it manually
-- \`@dependabot show <dependency name> ignore conditions\` will show all of the ignore conditions of the specified dependency
-- \`@dependabot ignore <dependency name> major version\` will close this group update PR and stop Dependabot creating any more for the specific dependency's major version (unless you unignore this specific dependency's major version or upgrade to it yourself)
-- \`@dependabot ignore <dependency name> minor version\` will close this group update PR and stop Dependabot creating any more for the specific dependency's minor version (unless you unignore this specific dependency's minor version or upgrade to it yourself)
-- \`@dependabot ignore <dependency name>\` will close this group update PR and stop Dependabot creating any more for the specific dependency (unless you unignore this specific dependency or upgrade to it yourself)
-- \`@dependabot unignore <dependency name>\` will remove all of the ignore conditions of the specified dependency
-- \`@dependabot unignore <dependency name> <ignore condition>\` will remove the ignore condition of the specified dependency and ignore conditions
-
-
-</details>
-`;
+		const mockPRBody = await fsActual.readFile(__dirname + '/grouped-pr-body-with-table.txt', 'utf-8');;
 
 		mockOctokit.rest.pulls.get.mockImplementation(() => Promise.resolve({
 			data: {
@@ -364,7 +110,7 @@ You can trigger Dependabot actions by commenting on this PR:
 		await run();
 
 		// Verify that writeFile was called with content containing changelog
-		const writeFileCalls = (writeFile as jest.Mock).mock.calls;
+		const writeFileCalls = (fs.writeFile as jest.Mock).mock.calls;
 		const hasChangelog = writeFileCalls.some((call) => {
 			const content = call[1] as string;
 			return content.includes('<details>') &&
@@ -375,11 +121,14 @@ You can trigger Dependabot actions by commenting on this PR:
 
 	it('does not extract changelog when include-changelog is false', async () => {
 		// Mock PR response with changelog
+		const mockPRBody = await fsActual.readFile(__dirname + '/single-pr-body.txt', 'utf-8');
+
 		mockOctokit.rest.pulls.get.mockImplementation(() => Promise.resolve({
 			data: {
-				title: 'Bump @auth/sveltekit from 0.3.11 to 0.3.12',
-				body: 'mock PR body with changelog',
+				title: 'Bump nanoid from 3.3.6 to 3.3.8',
+				body: mockPRBody,
 			},
+			status: 200
 		}));
 
 		// Mock include-changelog input as false (default)
@@ -391,8 +140,8 @@ You can trigger Dependabot actions by commenting on this PR:
 		await run();
 
 		// Verify that writeFile was called with content not containing changelog
-		const writeFileCalls = (writeFile as jest.Mock).mock.calls;
-		const hasChangelog = writeFileCalls.some((call) => {
+		const writeFileCalls = (fs.writeFile as jest.Mock).mock.calls;
+		const hasChangelog = writeFileCalls.every((call) => {
 			const content = call[1] as string;
 			return content.includes('<details>') ||
 				content.includes('Release notes');

--- a/__tests__/single-pr-body.txt
+++ b/__tests__/single-pr-body.txt
@@ -1,0 +1,60 @@
+Bumps [nanoid](https://github.com/ai/nanoid) from 3.3.6 to 3.3.8.
+<details>
+<summary>Changelog</summary>
+<p><em>Sourced from <a href="https://github.com/ai/nanoid/blob/main/CHANGELOG.md">nanoid's changelog</a>.</em></p>
+<blockquote>
+<h2>3.3.8</h2>
+<ul>
+<li>Fixed a way to break Nano ID by passing non-integer size (by <a href="https://github.com/myndzi"><code>@​myndzi</code></a>).</li>
+</ul>
+<h2>3.3.7</h2>
+<ul>
+<li>Fixed <code>node16</code> TypeScript support (by Saadi Myftija).</li>
+</ul>
+</blockquote>
+</details>
+<details>
+<summary>Commits</summary>
+<ul>
+<li><a href="https://github.com/ai/nanoid/commit/3044cd5e73f4cf31795f61f6e6b961c8c0a5c744"><code>3044cd5</code></a> Release 3.3.8 version</li>
+<li><a href="https://github.com/ai/nanoid/commit/4fe34959c34e5b3573889ed4f24fe91d1d3e7231"><code>4fe3495</code></a> Update size limit</li>
+<li><a href="https://github.com/ai/nanoid/commit/d643045f40d6dc8afa000a644d857da1436ed08c"><code>d643045</code></a> Fix pool pollution, infinite loop (<a href="https://redirect.github.com/ai/nanoid/issues/510">#510</a>)</li>
+<li><a href="https://github.com/ai/nanoid/commit/89d82d2ce4b0411e73ac7ccfe57bc03e932416e2"><code>89d82d2</code></a> Release 3.3.7 version</li>
+<li><a href="https://github.com/ai/nanoid/commit/5022c35acaaedd9da4b56cad37b02bbcb87635e1"><code>5022c35</code></a> Update dual-publish</li>
+<li><a href="https://github.com/ai/nanoid/commit/3e7a8e557b9d93a582ef2c3bb9f7306fc339ef35"><code>3e7a8e5</code></a> Remove benchmark from CI for v3</li>
+<li><a href="https://github.com/ai/nanoid/commit/d3561446aee52fdf38325e1d30c905d989a8ccd2"><code>d356144</code></a> Fix CI for v3</li>
+<li><a href="https://github.com/ai/nanoid/commit/37b25dfac2edfd73d7bbc88886e4c6067fac8619"><code>37b25df</code></a> Move to pnpm 8</li>
+<li>See full diff in <a href="https://github.com/ai/nanoid/compare/3.3.6...3.3.8">compare view</a></li>
+</ul>
+</details>
+<br />
+
+
+[![Dependabot compatibility score](https://dependabot-badges.githubapp.com/badges/compatibility_score?dependency-name=nanoid&package-manager=npm_and_yarn&previous-version=3.3.6&new-version=3.3.8)](https://docs.github.com/en/github/managing-security-vulnerabilities/about-dependabot-security-updates#about-compatibility-scores)
+
+Dependabot will resolve any conflicts with this PR as long as you don't alter it yourself. You can also trigger a rebase manually by commenting `@dependabot rebase`.
+
+[//]: # (dependabot-automerge-start)
+[//]: # (dependabot-automerge-end)
+
+---
+
+<details>
+<summary>Dependabot commands and options</summary>
+<br />
+
+You can trigger Dependabot actions by commenting on this PR:
+- `@dependabot rebase` will rebase this PR
+- `@dependabot recreate` will recreate this PR, overwriting any edits that have been made to it
+- `@dependabot merge` will merge this PR after your CI passes on it
+- `@dependabot squash and merge` will squash and merge this PR after your CI passes on it
+- `@dependabot cancel merge` will cancel a previously requested merge and block automerging
+- `@dependabot reopen` will reopen this PR if it is closed
+- `@dependabot close` will close this PR and stop Dependabot recreating it. You can achieve the same result by closing it manually
+- `@dependabot show <dependency name> ignore conditions` will show all of the ignore conditions of the specified dependency
+- `@dependabot ignore this major version` will close this PR and stop Dependabot creating any more for this major version (unless you reopen the PR or upgrade to it yourself)
+- `@dependabot ignore this minor version` will close this PR and stop Dependabot creating any more for this minor version (unless you reopen the PR or upgrade to it yourself)
+- `@dependabot ignore this dependency` will close this PR and stop Dependabot creating any more for this dependency (unless you reopen the PR or upgrade to it yourself)
+You can disable automated security fix PRs for this repo from the [Security Alerts page](https://github.com/quantizor/markdown-to-jsx/network/alerts).
+
+</details>

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -93,13 +93,21 @@ describe(`extractUpdateFromTitle`, () => {
 });
 
 describe('extractChangelog', () => {
-	it('extracts changelog for a package', async () => {
+	it('extracts changelog for a package from a grouped dependency PR', async () => {
 		const body = await readFile(__dirname + '/grouped-pr-body-with-table.txt', 'utf-8');
 		const changelog = extractChangelog(body, '@auth/sveltekit');
 		expect(changelog).toContain('<details>');
 		expect(changelog).toContain('</details>');
 		expect(changelog).toContain('Release notes');
 		// Skip version check as it's too fragile with invisible characters
+	});
+
+	it('extracts changelog for a package from a single dependency PR', async () => {
+		const body = await readFile(__dirname + '/single-pr-body.txt', 'utf-8');
+		const changelog = extractChangelog(body, 'nanoid');
+		expect(changelog).toContain('Changelog');
+		expect(changelog).toContain('Commits');
+		expect(changelog).toContain('37b25df')
 	});
 
 	it('returns undefined if no changelog is found', async () => {

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,10 @@ inputs:
     description: 'Email to use for git commits, defaults to "49699333+dependabot[bot]@users.noreply.github.com"'
     required: false
     default: 49699333+dependabot[bot]@users.noreply.github.com
+  include-changelog:
+    description: 'Whether to include the changelog from Dependabot PRs in the generated changeset'
+    required: false
+    default: 'false'
 
 runs:
   using: node20

--- a/src/main.ts
+++ b/src/main.ts
@@ -70,17 +70,17 @@ export async function run(): Promise<void> {
 			}
 		}
 
-		core.debug(`Found updates: ${JSON.stringify(updates, null, 4)}`);
-		if (updates.length === 0) {
-			core.info('no dependency updates found in PR');
-			return;
-		}
-
 		// Extract changelog for each update if enabled
 		if (includeChangelog) {
 			for (const update of updates) {
 				update.changelog = extractChangelog(pr.data.body ?? '', update.package);
 			}
+		}
+
+		core.debug(`Found updates: ${JSON.stringify(updates, null, 4)}`);
+		if (updates.length === 0) {
+			core.info('no dependency updates found in PR');
+			return;
 		}
 
 		let newUpdates = 0;
@@ -101,7 +101,7 @@ export async function run(): Promise<void> {
 			}
 			await writeFile(changesetPath, newChangeset, 'utf-8');
 			newUpdates++;
-			core.info(`✅ Created changeset for ${update.package} (${update.from} -> ${update.to}))`);
+			core.info(`✅ Created changeset for ${update.package} (${update.from} -> ${update.to})`);
 		}
 
 		if (newUpdates === 0) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,7 +42,7 @@ export async function run(): Promise<void> {
 			core.debug(JSON.stringify(pr, null, 4));
 			throw new Error('Error fetching PR');
 		}
-		core.debug(`Found PR: '${pr.data.title}'`);
+		core.debug(`Found PR: ${JSON.stringify(pr, null, 4)}`);
 
 		let updates: PackageUpdate[] = [];
 		if (isGroupedPR(pr.data.title)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,8 +49,9 @@ export function extractChangesetUpdate(body: string): PackageUpdate | undefined 
  * Extract the changelog from a PR body for a specific package
  */
 export function extractChangelog(body: string, pkg: string): string | undefined {
-	// take everything inside <details>
-	return body.slice(body.indexOf(`<details>`), body.lastIndexOf(`</details>`) + `</details>`.length) || undefined;
+	const groups = Array.from(body.matchAll(/\n?(.+)\n((?:<details>[\s\S]*?<\/details>\n?){2})/g));
+
+	return groups.find((group) => group[1].includes(pkg))?.[2];
 }
 
 export function generateChangeset(packageName: string, updateType: string, update: PackageUpdate) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ export function isGroupedPR(title: string) {
 	return groupedPRRegex.test(title);
 }
 
-export type PackageUpdate = { package: string; from: string; to: string };
+export type PackageUpdate = { package: string; from: string; to: string; changelog?: string };
 export function extractUpdates(body: string): PackageUpdate[] {
 	// e.g. Updates `wrangler` from 3.15.0 to 3.16.0
 	const updateRegex = /(?:\n|^)Updates `(.+?)` from (.+?) to (.+?)(?:\n|$)/g;
@@ -45,6 +45,14 @@ export function extractChangesetUpdate(body: string): PackageUpdate | undefined 
 	};
 }
 
+/**
+ * Extract the changelog from a PR body for a specific package
+ */
+export function extractChangelog(body: string, pkg: string): string | undefined {
+	// take everything inside <details>
+	return body.slice(body.indexOf(`<details>`), body.lastIndexOf(`</details>`) + `</details>`.length) || undefined;
+}
+
 export function generateChangeset(packageName: string, updateType: string, update: PackageUpdate) {
 	// e.g.
 	// ---
@@ -57,5 +65,6 @@ ${JSON.stringify(packageName)}: ${updateType}
 ---
 
 Bump ${update.package} from ${update.from} to ${update.to}
+${update.changelog ? `\n${update.changelog}` : ''}
 `;
 }


### PR DESCRIPTION
This optionally allows for the content of the changelog to be embedded into the changeset for reference. This sort of thing is helpful for patch bumps of dependencies to surface what underlying change you are taking.